### PR TITLE
Improve DOCX handling and scoring tests

### DIFF
--- a/TAP_codebook.yaml
+++ b/TAP_codebook.yaml
@@ -55,7 +55,7 @@ categories:
       - Anmerkungen fördern
       - antwortet auf Fragen
     regex:
-      - Gruppen(arbet|arbeit)
+      - Gruppenarbeit(en)?
       - Diskussion(en)?
       - "Fragen\\s*(und|&)?\\s*Antwort(en)?"
       - moderier

--- a/semi_auto_coder_v2.py
+++ b/semi_auto_coder_v2.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """
-semi_auto_coder_v4.py — Semi-automatisches Kodieren mit Redirects, Valenz (Kontext + Heuristik)
+semi_auto_coder_v2.py — Semi-automatisches Kodieren mit Redirects, Valenz (Kontext + Heuristik)
 Install:
     pip install python-docx pandas pyyaml rapidfuzz
     # optional:
     # pip install spacy && python -m spacy download de_core_news_sm
 
 Beispiel:
-    python semi_auto_coder_v4.py ./data TAP_codebook.yaml output/out.csv -r \
+    python semi_auto_coder_v2.py ./data TAP_codebook.yaml output/out.csv -r \
       -k 3 --min-score 1.0 --fuzzy-threshold 82 --w-fuzzy 1.0 --lemmatize
 """
 import argparse, csv, re, sys, unicodedata
@@ -68,7 +68,8 @@ def find_docx_paths(path: Path, recursive: bool) -> List[Path]:
     if path.is_file() and path.suffix.lower() == ".docx":
         return [path]
     if path.is_dir():
-        return [p for p in (path.rglob("*.docx") if recursive else path.glob("*.docx")) if p.is_file()]
+        globber = path.rglob("*") if recursive else path.glob("*")
+        return [p for p in globber if p.is_file() and p.suffix.lower() == ".docx"]
     return []
 
 def detect_ctx_valence(text: str) -> Optional[str]:

--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from semi_auto_coder_v2 import score_text
+
+
+def test_redirect_scores_and_evidence():
+    codebook = {
+        "categories": {
+            "A": {
+                "keywords": ["foo"],
+                "regex": [],
+                "excludes": [],
+                "redirects": [
+                    {"pattern": "bar", "to": "B"}
+                ],
+            },
+            "B": {"keywords": []},
+        }
+    }
+
+    scores, _, hits = score_text(
+        "foo bar", codebook,
+        fuzzy_threshold=100,
+        w_keyword=1.0,
+        w_regex=0.0,
+        w_fuzzy=0.0,
+        w_excl=-1.0,
+        use_lemma=False,
+    )
+
+    assert scores["B"] == pytest.approx(1.01)
+    assert scores["A"] == pytest.approx(0.8)
+    assert any("REDIR from A" in h for h in hits["B"])
+    assert any("REDIR→B:bar" in h for h in hits["B"])


### PR DESCRIPTION
## Summary
- Fix codebook typo for group work regex
- Make DOCX search case-insensitive and correct script docs
- Add test verifying redirect scoring logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ada4161e1c8325ac9877f007477ba4