### PR TITLE
feat: add confidence filter in review app

### DIFF
--- a/review_app.py
+++ b/review_app.py
@@ -18,11 +18,46 @@ with open(args.codebook, "r", encoding="utf-8") as f:
 
 categories = list((codebook.get("categories") or {}).keys())
 
+# Vorverarbeitete Konfidenzwerte für eine spätere Filterung
+def parse_conf(val):
+    try:
+        return float((val or "").split("|")[0])
+    except Exception:
+        return None
+
+df["conf_val"] = df.get("confidences", pd.Series(dtype=str)).map(parse_conf)
+
 st.set_page_config(page_title="Coding Review", layout="wide")
 st.title("Halbautomatisches Kodieren – Review")
 
 if "idx" not in st.session_state:
     st.session_state.idx = 0
+
+# Auswahlmenü zur Filterung nach Konfidenzstufen
+filter_opts = ["Alle", "Gering", "Mittel", "Hoch"]
+if "conf_filter" not in st.session_state:
+    st.session_state.conf_filter = "Alle"
+conf_choice = st.selectbox(
+    "Konfidenzfilter",
+    filter_opts,
+    index=filter_opts.index(st.session_state.conf_filter),
+)
+st.session_state.conf_filter = conf_choice
+
+if conf_choice == "Gering":
+    view_df = df[df["conf_val"] < 0.4]
+elif conf_choice == "Mittel":
+    view_df = df[(df["conf_val"] >= 0.4) & (df["conf_val"] < 0.8)]
+elif conf_choice == "Hoch":
+    view_df = df[df["conf_val"] >= 0.8]
+else:
+    view_df = df
+
+if len(view_df) == 0:
+    st.info("Keine Einträge für diese Konfidenzstufe.")
+    st.stop()
+
+st.session_state.idx = min(st.session_state.idx, len(view_df) - 1)
 
 def save(df):
     out = Path(args.csv).with_suffix(".reviewed.csv")
@@ -31,14 +66,14 @@ def save(df):
 
 c1, c2, c3 = st.columns([1,6,1])
 with c2:
-    st.write(f"Eintrag {st.session_state.idx+1} / {len(df)}")
+    st.write(f"Eintrag {st.session_state.idx+1} / {len(view_df)}")
 
 if c1.button("◀ Zurück"):
     st.session_state.idx = max(0, st.session_state.idx - 1)
 if c3.button("Weiter ▶"):
-    st.session_state.idx = min(len(df)-1, st.session_state.idx + 1)
+    st.session_state.idx = min(len(view_df)-1, st.session_state.idx + 1)
 
-row = df.iloc[st.session_state.idx]
+row = view_df.iloc[st.session_state.idx]
 
 def confidence_text(c):
     if c is None:
@@ -53,11 +88,7 @@ def confidence_text(c):
 
 evidence = (row.get("evidence", "") or "").split("|")[0]
 current = (row.get("suggested_labels", "") or "").split("|")[0]
-conf_raw = (row.get("confidences", "") or "").split("|")[0]
-try:
-    conf_val = float(conf_raw)
-except Exception:
-    conf_val = None
+conf_val = row.get("conf_val")
 
 st.subheader("Automatische Zuordnung")
 st.write(f"**Gefundener String:** {evidence}")
@@ -72,7 +103,7 @@ if not st.session_state.changing:
     if c4.button("Bestätigen"):
         df.at[row.name, "final_label"] = current
         save(df)
-        st.session_state.idx = min(len(df)-1, st.session_state.idx + 1)
+        st.session_state.idx = min(len(view_df)-1, st.session_state.idx + 1)
     if c5.button("Ändern"):
         st.session_state.changing = True
 else:
@@ -81,7 +112,7 @@ else:
         df.at[row.name, "final_label"] = new_label
         save(df)
         st.session_state.changing = False
-        st.session_state.idx = min(len(df)-1, st.session_state.idx + 1)
+        st.session_state.idx = min(len(view_df)-1, st.session_state.idx + 1)
 
 # Optional: Leitfaden-Schnipsel anzeigen (falls im YAML meta/desc vorhanden)
 with st.expander("Leitfaden (Ausschnitt)"):


### PR DESCRIPTION
## Summary
- allow filtering review items by confidence level (low/medium/high) via select menu
- pre-process confidence values for easier filtering and navigation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adc7cfd16c8325927382d923d39b0f